### PR TITLE
Revamp portfolio content

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,126 +1,189 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Byeong Gwon Lee | Portfolio</title>
-  <meta name="description" content="3D Reconstruction, SLAM, Depth Estimation" />
-  <meta property="og:title" content="Byeong Gwon Lee | Portfolio">
-  <meta property="og:description" content="3D Reconstruction, SLAM, Depth Estimation">
-  <meta property="og:type" content="website">
-  <meta property="og:image" content="assets/img/og-preview.png">
-  <link rel="icon" href="assets/img/favicon.png">
-  <link rel="stylesheet" href="styles.css" />
-</head>
-<body>
-  <header class="hero" id="top">
-    <h1>Byeong Gwon Lee</h1>
-    <p class="kicker">3D Reconstruction · SLAM · Depth Estimation</p>
-    <div class="links">
-      <a class="btn" href="#projects">Projects</a>
-      <a class="btn" href="#publications">Publications</a>
-      <a class="btn" href="#demos">Demos</a>
-      <a class="btn" href="#about">About</a>
-      <a class="btn" href="mailto:lee971009@naver.com">Contact</a>
-      <a class="btn" href="cv/Byeonggwon_Lee_CV.pdf">Download CV</a>
-    </div>
-  </header>
-
-  <nav class="top">
-    <div class="inner">
-      <a href="#projects">Projects</a>
-      <a href="#publications">Publications</a>
-      <a href="#demos">Demos</a>
-      <a href="#tech">Tech Stack</a>
-      <a href="#talks">Talks & Awards</a>
-      <a href="#about">About</a>
-    </div>
-  </nav>
-
-  <main>
-    <section id="projects">
-      <h2>Featured Projects</h2>
-      <div class="grid">
-        <article class="card">
-          <h3>Online 3D Gaussian Splatting SLAM</h3>
-          <p>Online 3D modeling from RGB-only streams with uncertainty-driven novel view selection to improve completeness.</p>
-          <ul class="clean">
-            <li>Approach: DROID-SLAM + MVS/Depth Fusion, Gaussian Splatting</li>
-            <li>Result: Better completeness and fidelity in indoor/outdoor scenes</li>
-          </ul>
-          <p><a href="#" target="_blank">Code</a> · <a href="#" target="_blank">Video</a> · <a href="#" target="_blank">Slides</a></p>
-          <div class="badges">
-            <span class="badge">Python</span><span class="badge">PyTorch</span><span class="badge">OpenCV</span><span class="badge">C++</span>
-          </div>
-        </article>
-        <article class="card">
-          <h3>Drone-based Offline 3D Reconstruction</h3>
-          <p>High-res modeling pipeline on drone imagery.</p>
-          <ul class="clean">
-            <li>Sparse: COLMAP SfM</li><li>Dense: OpenMVS Mesh + Texture</li>
-          </ul>
-          <p><a href="#" target="_blank">Report</a> · <a href="#" target="_blank">Demo</a></p>
-          <div class="badges">
-            <span class="badge">SfM</span><span class="badge">MVS</span><span class="badge">OpenGL</span>
-          </div>
-        </article>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Byeong Gwon Lee | Portfolio</title>
+    <meta
+      name="description"
+      content="3D Reconstruction, SLAM, Depth Estimation"
+    />
+    <meta property="og:title" content="Byeong Gwon Lee | Portfolio" />
+    <meta
+      property="og:description"
+      content="3D Reconstruction, SLAM, Depth Estimation"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="assets/img/og-preview.png" />
+    <link rel="icon" href="assets/img/favicon.png" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero" id="top">
+      <h1>Byeong Gwon Lee</h1>
+      <p class="kicker">3D Reconstruction · SLAM · Depth Estimation</p>
+      <div class="links">
+        <a class="btn" href="#projects">Projects</a>
+        <a class="btn" href="#publications">Publications</a>
+        <a class="btn" href="#tech">Tech Stack</a>
+        <a class="btn" href="#about">About</a>
+        <a class="btn" href="#education">Education</a>
+        <a class="btn" href="#research">Research</a>
+        <a class="btn" href="#projects-list">Project List</a>
+        <a class="btn" href="mailto:lee971009@naver.com">Contact</a>
+        <a class="btn" href="cv/Byeonggwon_Lee_CV.pdf">Download CV</a>
       </div>
-    </section>
+    </header>
 
-    <section id="publications">
-      <h2>Publications</h2>
-      <ul class="clean">
-        <li><strong>MVS-GS: High-Quality 3D Gaussian Splatting Mapping via Online Multi-View Stereo</strong>, IEEE Access, 2025. <a href="https://arxiv.org/abs/2412.19130" target="_blank">arXiv</a></li>
-        <li>
-          <strong>Online 3D Gaussian Splatting Modeling with Novel View Selection</strong>, IJCAI 2025. <a href="https://arxiv.org/abs/2508.14014" target="_blank">arXiv</a> ·
-          <a href="poster/IJCAI2025_Poster_v2.pdf" target="_blank">Poster (PDF)</a>
-        </li>
-      </ul>
-    </section>
-
-    <section id="demos">
-      <h2>Demos</h2>
-      <div class="grid">
-        <div class="card">
-          <img src="assets/img/demo1.png" alt="Online 3DGS SLAM demo" style="width:100%;border-radius:8px">
-          <p><a href="#" target="_blank">YouTube: Online 3DGS SLAM</a></p>
+    <main>
+      <section id="projects">
+        <h2>Featured Projects</h2>
+        <div class="grid">
+          <article class="card">
+            <h3>Drone-based Offline 3D Reconstruction</h3>
+            <p>
+              A complete pipeline for high-resolution modeling from drone
+              imagery, from flight planning to textured mesh output.
+            </p>
+            <ul class="clean">
+              <li>Sparse reconstruction with COLMAP SfM</li>
+              <li>Dense mesh and texture generation via OpenMVS</li>
+              <li>Designed for large-scale outdoor scenes</li>
+            </ul>
+            <div class="badges">
+              <span class="badge">SfM</span><span class="badge">MVS</span
+              ><span class="badge">OpenGL</span>
+            </div>
+          </article>
         </div>
-        <div class="card">
-          <img src="assets/img/demo2.png" alt="Drone reconstruction demo" style="width:100%;border-radius:8px">
-          <p><a href="#" target="_blank">Drone Reconstruction Walkthrough</a></p>
+      </section>
+
+      <section id="publications">
+        <h2>Publications</h2>
+        <ul class="clean">
+          <li>
+            <strong
+              >MVS-GS: High-Quality 3D Gaussian Splatting Mapping via Online
+              Multi-View Stereo</strong
+            >, IEEE Access, 2025.
+            <a href="https://arxiv.org/abs/2412.19130" target="_blank">arXiv</a>
+          </li>
+          <li>
+            <strong
+              >Online 3D Gaussian Splatting Modeling with Novel View
+              Selection</strong
+            >, IJCAI 2025.
+            <a href="https://arxiv.org/abs/2508.14014" target="_blank">arXiv</a>
+            ·
+            <a href="poster/IJCAI2025_Poster_v2.pdf" target="_blank"
+              >Poster (PDF)</a
+            >
+          </li>
+        </ul>
+      </section>
+
+      <section id="tech">
+        <h2>Tech Stack</h2>
+        <div class="badges">
+          <span class="badge">Python</span><span class="badge">PyTorch</span
+          ><span class="badge">OpenCV</span> <span class="badge">C++</span
+          ><span class="badge">Shell</span><span class="badge">Linux</span>
+          <span class="badge">OpenGL</span><span class="badge">COLMAP</span
+          ><span class="badge">OpenMVS</span>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section id="tech">
-      <h2>Tech Stack</h2>
-      <div class="badges">
-        <span class="badge">Python</span><span class="badge">PyTorch</span><span class="badge">OpenCV</span>
-        <span class="badge">C++</span><span class="badge">Shell</span><span class="badge">Linux</span>
-        <span class="badge">OpenGL</span><span class="badge">COLMAP</span><span class="badge">OpenMVS</span>
-      </div>
-    </section>
+      <section id="about">
+        <h2>About</h2>
+        <p>
+          I'm a computer vision researcher and M.S. student at Dongguk
+          University focusing on monocular SLAM, multi-view stereo, and depth
+          estimation. My interests span both real-time online modeling and
+          high-quality offline reconstruction.
+        </p>
+        <p>
+          Previously I studied Software Engineering at Hanyang University and
+          spent time as a research intern and data scientist at AI Image, RTM. I
+          enjoy building practical 3D vision systems that bridge research and
+          field applications.
+        </p>
+        <p>
+          Contact:
+          <a href="mailto:lee971009@naver.com">lee971009@naver.com</a> ·
+          <a href="mailto:lbg030@dgu.ac.kr">lbg030@dgu.ac.kr</a> ·
+          <a href="https://github.com/lbg030" target="_blank">GitHub</a>
+        </p>
+      </section>
 
-    <section id="talks">
-      <h2>Talks & Awards</h2>
-      <ul class="clean">
-        <li>Talk: Online 3DGS with Novel View Selection (IJCAI 2025)</li>
-      </ul>
-    </section>
+      <section id="education">
+        <h2>Education</h2>
+        <ul class="clean">
+          <li>
+            <strong>Catholic Kwandong University</strong>, Department of
+            Broadcasting, Gangneung, Korea (Mar. 2016 – May 2017) – Dropped out,
+            GPA 3.688 / 4.5
+          </li>
+          <li>
+            <strong>Hanyang University</strong>, Division of Software, Ansan,
+            Korea (Mar. 2020 – Feb. 2024) – B.S. in Software Engineering,
+            Advisor: Sungui Park, GPA 3.68 / 4.5
+          </li>
+          <li>
+            <strong>Dongguk University</strong>, Dept. of Computer Science and
+            Artificial Intelligence, Seoul, Korea (Feb. 2024 – Present) – M.S.
+            Student, Advisor: Soohwan Song, GPA 4.5 / 4.5
+          </li>
+        </ul>
+      </section>
 
-    <section id="about">
-      <h2>About</h2>
-      <p>I'm a computer vision researcher focusing on monocular SLAM, multi-view stereo, and depth estimation. I work on both real-time online modeling and high-quality offline reconstruction.</p>
-      <p>Contact: <a href="mailto:lee971009@naver.com">lee971009@naver.com</a> · <a href="mailto:lbg030@dgu.ac.kr">lbg030@dgu.ac.kr</a> · <a href="https://github.com/lbg030" target="_blank">GitHub</a></p>
-    </section>
-  </main>
+      <section id="research">
+        <h2>Research Experiences</h2>
+        <ul class="clean">
+          <li>
+            Research Intern at AI Image, RTM, Korea (Sep. 2022 – Dec. 2022) /
+            Intern
+          </li>
+          <li>
+            Researcher at AI Image, RTM, Korea (Jan. 2023 – Feb. 2024) / Data
+            Scientist
+          </li>
+          <li>
+            Research Student at Dept. of Computer Science and Artificial
+            Intelligence, Dongguk Univ., Korea (Feb. 2024 – Present) / Computer
+            Vision Researcher
+          </li>
+        </ul>
+      </section>
 
-  <footer class="site">
-    © <span id="y"></span> Byeong Gwon Lee · Hosted on GitHub Pages
-  </footer>
+      <section id="projects-list">
+        <h2>Projects</h2>
+        <ul class="clean">
+          <li>
+            같은 샘플의 다양한 각도에서 촬영된 이미지에서 결함 객체 찾기, 대덕
+            전자, Korea (Apr. 2023 – Jun. 2023)
+          </li>
+          <li>
+            고해상도로 촬영된 화장품 용기의 결함 찾기, 서바우적, Korea (Mar.
+            2023 – Dec. 2023)
+          </li>
+          <li>
+            드론 활용 실시간 3차원 복원을 위한 다집 샘플링 기술 개발, Mobility
+            One Inc., Korea (Oct. 2024 – Present)
+          </li>
+          <li>
+            드론으로 촬영된 이미지를 활용한 3D Reconstruction, Mobility One
+            Inc., Korea (Jun. 2025 – Present)
+          </li>
+        </ul>
+      </section>
+    </main>
 
-  <script>
-    document.getElementById('y').textContent = new Date().getFullYear();
-  </script>
-</body>
+    <footer class="site">
+      © <span id="y"></span> Byeong Gwon Lee · Hosted on GitHub Pages
+    </footer>
+
+    <script>
+      document.getElementById("y").textContent = new Date().getFullYear();
+    </script>
+  </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,33 +1,121 @@
-
-:root{ --w: 980px; }
-* { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
-body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Apple SD Gothic Neo, sans-serif; color:#111; line-height:1.65; }
-a { color: inherit; }
-a.btn { display:inline-block; padding:10px 14px; border:1px solid #222; border-radius:10px; text-decoration:none; }
-a.btn:hover { background:#111; color:#fff; }
-header.hero { max-width: var(--w); margin: 48px auto 0; padding: 0 20px 24px; }
-.hero h1 { margin:0 0 10px; font-size:40px; }
-.hero p.kicker { color:#444; margin:0 0 16px; }
-.hero .links a { margin-right:10px; }
-nav.top { position: sticky; top: 0; background: #fff; border-top: 1px solid #eee; border-bottom:1px solid #eee; z-index: 10; }
-nav.top .inner { max-width: var(--w); margin: 0 auto; padding: 10px 20px; display:flex; gap:12px; flex-wrap:wrap; }
-nav.top a { text-decoration:none; color:#333; padding:6px 0; }
-main { max-width: var(--w); margin: 0 auto; padding: 24px 20px 60px; }
-section { margin: 36px 0; }
-h2 { margin: 24px 0 8px; border-bottom: 1px solid #eee; padding-bottom: 8px; }
-.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 14px; }
-.card { border:1px solid #eee; border-radius:12px; padding:16px; }
-.card h3 { margin-top:0; }
-.badges { display:flex; gap:8px; flex-wrap:wrap; margin-top:8px; }
-.badge { font-size:12px; padding:4px 8px; border:1px solid #ddd; border-radius:999px; }
-footer.site { border-top:1px solid #eee; padding:20px; color:#666; text-align:center; }
-ul.clean { padding-left: 18px; }
+:root {
+  --w: 980px;
+}
+* {
+  box-sizing: border-box;
+}
+html {
+  scroll-behavior: smooth;
+}
+body {
+  margin: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    Segoe UI,
+    Roboto,
+    Noto Sans,
+    Apple SD Gothic Neo,
+    sans-serif;
+  color: #111;
+  line-height: 1.65;
+}
+a {
+  color: inherit;
+}
+a.btn {
+  display: inline-block;
+  padding: 10px 14px;
+  border: 1px solid #222;
+  border-radius: 10px;
+  text-decoration: none;
+}
+a.btn:hover {
+  background: #111;
+  color: #fff;
+}
+header.hero {
+  max-width: var(--w);
+  margin: 48px auto 0;
+  padding: 0 20px 24px;
+}
+.hero h1 {
+  margin: 0 0 10px;
+  font-size: 40px;
+}
+.hero p.kicker {
+  color: #444;
+  margin: 0 0 16px;
+}
+.hero .links a {
+  margin-right: 10px;
+}
+main {
+  max-width: var(--w);
+  margin: 0 auto;
+  padding: 24px 20px 60px;
+}
+section {
+  margin: 36px 0;
+}
+h2 {
+  margin: 24px 0 8px;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 8px;
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+.card {
+  border: 1px solid #eee;
+  border-radius: 12px;
+  padding: 16px;
+}
+.card h3 {
+  margin-top: 0;
+}
+.badges {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+.badge {
+  font-size: 12px;
+  padding: 4px 8px;
+  border: 1px solid #ddd;
+  border-radius: 999px;
+}
+footer.site {
+  border-top: 1px solid #eee;
+  padding: 20px;
+  color: #666;
+  text-align: center;
+}
+ul.clean {
+  padding-left: 18px;
+}
 @media (prefers-color-scheme: dark) {
-  body { background:#0c0c0c; color:#eaeaea; }
-  nav.top, h2 { border-color:#222; }
-  .card { border-color:#222; }
-  .badge { border-color:#333; }
-  a.btn { border-color:#999; }
-  a.btn:hover { background:#eaeaea; color:#111; }
+  body {
+    background: #0c0c0c;
+    color: #eaeaea;
+  }
+  h2 {
+    border-color: #222;
+  }
+  .card {
+    border-color: #222;
+  }
+  .badge {
+    border-color: #333;
+  }
+  a.btn {
+    border-color: #999;
+  }
+  a.btn:hover {
+    background: #eaeaea;
+    color: #111;
+  }
 }


### PR DESCRIPTION
## Summary
- Streamline navigation by removing demos and talks sections and expanding header links
- Highlight drone-based offline 3D reconstruction project and drop unused entries
- Add detailed About, Education, Research Experiences, and Projects sections

## Testing
- `npx prettier --check index.html styles.css`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a626017510832589e88bd3b7e734f2